### PR TITLE
Implement WriteHTTPResponseBodyToFile via valve's filesystem.

### DIFF
--- a/Extension/extension.cpp
+++ b/Extension/extension.cpp
@@ -72,6 +72,20 @@ void SteamWorks::SDK_OnUnload()
 	delete this->pSWGameData;
 }
 
+bool SteamWorks::SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlen, bool late)
+{
+	GET_V_IFACE_CURRENT(GetFileSystemFactory, this->pFileSystem, IFileSystem, FILESYSTEM_INTERFACE_VERSION);
+
+	return true;
+}
+
+bool SteamWorks::SDK_OnMetamodUnload(char *error, size_t maxlen)
+{
+	this->pFileSystem = NULL;
+
+	return true;
+}
+
 CSteamID SteamWorks::CreateCommonCSteamID(IGamePlayer *pPlayer, const cell_t *params, unsigned char universeplace = 2, unsigned char typeplace = 3)
 {
 	EUniverse universe = k_EUniversePublic;

--- a/Extension/extension.h
+++ b/Extension/extension.h
@@ -51,6 +51,8 @@
 #include "swgsdetours.h"
 #include "swhttp.h"
 
+#include <filesystem.h>
+
 /**
  * @brief Sample implementation of the SDK Extension.
  * Note: Uncomment one of the pre-defined virtual functions in order to use it.
@@ -103,7 +105,7 @@ public:
 	 * @param late			Whether or not Metamod considers this a late load.
 	 * @return				True to succeed, false to fail.
 	 */
-	//virtual bool SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlength, bool late);
+	virtual bool SDK_OnMetamodLoad(ISmmAPI *ismm, char *error, size_t maxlength, bool late);
 
 	/**
 	 * @brief Called when Metamod is detaching, after the extension version is called.
@@ -113,7 +115,7 @@ public:
 	 * @param maxlength		Maximum size of error buffer.
 	 * @return				True to succeed, false to fail.
 	 */
-	//virtual bool SDK_OnMetamodUnload(char *error, size_t maxlength);
+	virtual bool SDK_OnMetamodUnload(char *error, size_t maxlength);
 
 	/**
 	 * @brief Called when Metamod's pause state is changing.
@@ -142,6 +144,8 @@ public:
 	SteamWorksGSDetours *pGSDetours;
 	SteamWorksHTTP *pSWHTTP;
 	SteamWorksHTTPNatives *pSWHTTPNatives;
+
+	IFileSystem *pFileSystem;
 };
 
 extern SteamWorks g_SteamWorks;

--- a/Pawn/includes/SteamWorks.inc
+++ b/Pawn/includes/SteamWorks.inc
@@ -238,6 +238,7 @@ funcenum SteamWorksHTTPBodyCallback
 };
 
 native bool:SteamWorks_GetHTTPResponseBodyCallback(Handle:hRequest, SteamWorksHTTPBodyCallback:fCallback, any:data = 0, Handle:hPlugin = INVALID_HANDLE);
+native bool:SteamWorks_WriteHTTPResponseBodyToFile(Handle:hRequest, const String:sFileName[]);
 
 forward SW_OnValidateClient(ownerauthid, authid);
 forward SteamWorks_OnValidateClient(ownerauthid, authid);
@@ -305,5 +306,6 @@ public __ext_SteamWorks_SetNTVOptional()
 	MarkNativeAsOptional("SteamWorks_SetHTTPRequestRawPostBody");
 
 	MarkNativeAsOptional("SteamWorks_GetHTTPResponseBodyCallback");
+	MarkNativeAsOptional("SteamWorks_WriteHTTPResponseBodyToFile");
 }
 #endif


### PR DESCRIPTION
This implementation requires IFileSystem, which I believe doesn't allow a single build of the extension to be portable across all games, and will instead require per-game builds.
