### PR TITLE
Fixed steam_api failing to open when using gamedata.

### DIFF
--- a/Extension/swgsdetours.cpp
+++ b/Extension/swgsdetours.cpp
@@ -60,7 +60,11 @@ SteamWorksGSDetours::SteamWorksGSDetours()
 		pConfig = g_SteamWorks.pSWGameData->GetGameData();
 		if (pConfig)
 		{
-			pLibSteamPath = pConfig->GetKeyValue("LibSteamAPI");
+			const char *kvLibSteamAPI = pConfig->GetKeyValue("LibSteamAPI");
+			if (kvLibSteamAPI)
+			{
+				pLibSteamPath = kvLibSteamAPI;
+			}
 		}
 	}
 


### PR DESCRIPTION
When using custom interface versions via gamedata without defining `LibSteamAPI`, `pLibSteamPath` becomes null and all detours fail to initialize.
