### PR TITLE
Fix streaming response callbacks

### DIFF
--- a/Extension/swhttprequest.h
+++ b/Extension/swhttprequest.h
@@ -33,14 +33,14 @@ class SteamWorksHTTPRequest
 
 	public:
 		void OnHTTPRequestCompleted(HTTPRequestCompleted_t *pRequest, bool bFailed);
-		void OnHTTPHeadersReceived(HTTPRequestHeadersReceived_t *pRequest, bool bFailed);
-		void OnHTTPDataReceived(HTTPRequestDataReceived_t *pRequest, bool bFailed);
 
 	public:
 		CCallResult<SteamWorksHTTPRequest, HTTPRequestCompleted_t> CompletedCallResult;
-		CCallResult<SteamWorksHTTPRequest, HTTPRequestHeadersReceived_t> HeadersCallResult;
-		CCallResult<SteamWorksHTTPRequest, HTTPRequestDataReceived_t> DataCallResult;
-
+	
+	public:
+		STEAM_GAMESERVER_CALLBACK_MANUAL(SteamWorksHTTPRequest, OnHTTPHeadersReceived, HTTPRequestHeadersReceived_t, m_CallbackHTTPRequestHeadersReceived);
+		STEAM_GAMESERVER_CALLBACK_MANUAL(SteamWorksHTTPRequest, OnHTTPDataReceived, HTTPRequestDataReceived_t, m_CallbackHTTPRequestDataReceived);
+	
 	public:
 		IChangeableForward *pCompletedForward;
 		IChangeableForward *pHeadersReceivedForward;


### PR DESCRIPTION
This changes callback handling when headers and data are received. Before this pr if you register data or headers callbacks, they wont work as expected, and would fire when RequestCompleted callback is triggered, and in most cases headers and data callbacks got incorrect parameters (not sure if it ever worked, for me it was always incorrect) as it was propagated by HTTPRequestCompleted_t struct and not the others.

This pr changes the callbacks to be global ones, which do work in this instance, but they require manually filtering which request it's called for. Thus there were multiple options for me to take, one is store all the ongoing requests in a list and have one global callback instance to filter there all the requests and fire appropriate forwards. Second as how I did it here, I'm instantiating a new callbacks each time you create a new request, but I do filter them by checking the request handle as it's conveniently provided in the resulting structures. This tho does comes with its downside as it's basically would mean that for each new request other callbacks would be called the same amount of times as there are requests active (yet they would do nothing), not sure if it's anything crucial performance wise.

I also would like to hear your opinion on that matter as well.